### PR TITLE
Adds registry path creation to fix property creation

### DIFF
--- a/bucket/byond.json
+++ b/bucket/byond.json
@@ -19,7 +19,16 @@
 	],
 	"persist": "data",
 	"env_add_path": "bin",
-	"post_install": "New-ItemProperty -Path \"HKCU:\\Software\\Dantom\\BYOND\" -Name \"userpath\" -Value \"$persist_dir\\data\" -PropertyType String -Force",
+	"post_install": [
+		"$regpath = \"HKCU:\\Software\\Dantom\\BYOND\"",
+		"if (!(Test-Path \"$regpath\")) {",
+			"Write-Host \"Registry path '$regpath' doesn't exist. Creating...\"",
+			"New-Item -Path \"$regpath\" -Type Directory -Force | Out-Null",
+		"}",
+		"$datpath = \"$persist_dir\\data\"",
+		"Write-Host -F Yellow \"INFO: BYOND user folder will be set to scoop persistent data directory '$datpath'.`nYou can change the destination in the program settings in Preferences > Advanced > User directory.\"",
+		"New-ItemProperty -Path \"$regpath\" -Name \"userpath\" -Value \"$datpath\" -PropertyType String -Force | Out-Null"
+	],
 	"checkver": {
 		"url": "https://secure.byond.com/download/version.txt",
 		"regex": "^(?<stable_major>[0-9]{3})\\.(?<stable_minor>[0-9]{4})[\\n\\r]{1,2}(?<beta_major>[0-9]{3})\\.(?<beta_minor>[0-9]{4})$",


### PR DESCRIPTION
Hello! I want to push a few lines to fix something I've noticed when tried to install your `byond.json` package. Unsure if it's need tho. BTW, thanks for it!

`New-ItemProperty` fails to add new entry due lack of the registry path definition:
> New-ItemProperty: Cannot find path 'HKCU:\Software\Dantom\BYOND' because it does not exist.

This should expand `post_install` and add the path check, so if there no BYOND path in registry, it will create such and output verbose info.

Not sure if you actually need user data destination override here if it's possible to set it from the program settings. Besides, it may become more tricky, considering that BYOND is not designed to be portable and you may used an .exe installer before (which sets config to Documents/BYOND by default).

Maybe it's worth a shot to request a feature from Lummox, so you can somehow manage config portability without relying on registry at all. Say, creating a dummy `Portable` file or creating a folder `data` inside installation folder will have more priority over registry. This will achieve a better config persistence/independence.