### PR TITLE
Adding webview2 as an optional package

### DIFF
--- a/bucket/byond.json
+++ b/bucket/byond.json
@@ -9,7 +9,8 @@
     "extract_dir": "byond",
     "bin": "bin\\byond.exe",
     "suggest": {
-        "vcredist": "extras/vcredist"
+        "vcredist": "extras/vcredist",
+        "webview2": "arch3rPro_PST-Bucket/webview2"
     },
     "shortcuts": [
         [


### PR DESCRIPTION
Hi. I've added webview2 as an optional package. I looked at the latest packages in the public buckets and chose the best one for this.

Interestingly, there's no latest version; at most, there's one package, and that's six months old.

If everything's OK, I can do the same for the beta version.

<img width="1635" height="984" alt="image" src="https://github.com/user-attachments/assets/d2e8aacf-cc47-4017-9b03-316c1f14ba04" />


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
